### PR TITLE
Removing 'profile: psmu' from serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,6 @@ provider:
     name: aws
     region: us-east-1
     runtime: provided
-    profile: psmu
     memorySize: 512
 
 package:


### PR DESCRIPTION
I needed to remove 'profile: psmu' from serverless.yml for this to work